### PR TITLE
fix: prevent error when ID is not present in data

### DIFF
--- a/src/Traits/Obfuscatable.php
+++ b/src/Traits/Obfuscatable.php
@@ -46,8 +46,9 @@ trait Obfuscatable
         $data = parent::toArray();
 
         // Add or modify data as needed
-        $data[$this->getKeyName()] = Obfuscate::encode($data[$this->getKeyName()]);
-
+        if(isset($data[$this->getKeyName()])){
+            $data[$this->getKeyName()] = Obfuscate::encode($data[$this->getKeyName()]);
+        }
         return $data;
     }
 }


### PR DESCRIPTION
Added a check to ensure the ID key is present in the data array before applying Obfuscate encoding. This prevents an "undefined index" error when the ID is missing.