### PR TITLE
Alter return type class name to enable static analysis

### DIFF
--- a/src/Traits/Obfuscatable.php
+++ b/src/Traits/Obfuscatable.php
@@ -34,9 +34,9 @@ trait Obfuscatable
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return \EvoMark\LaravelIdObfuscator\Eloquent\Builder|static
+     * @return \EvoMark\LaravelIdObfuscator\Eloquent\Builder
      */
-    public function newEloquentBuilder($query)
+    public function newEloquentBuilder($query): Builder
     {
         return new Builder($query);
     }

--- a/src/Traits/Obfuscatable.php
+++ b/src/Traits/Obfuscatable.php
@@ -34,7 +34,7 @@ trait Obfuscatable
      * Create a new Eloquent query builder for the model.
      *
      * @param  \Illuminate\Database\Query\Builder  $query
-     * @return EvoMark\LaravelIdObfuscator\Eloquent\Builder|static
+     * @return \EvoMark\LaravelIdObfuscator\Eloquent\Builder|static
      */
     public function newEloquentBuilder($query)
     {


### PR DESCRIPTION
## Issue 1

After installing this library into a project, [larastan](https://github.com/larastan/larastan) was no longer able to analyse the project. It threw the following error for each of the classes which used the `Obfuscatable` trait:

```
Internal error: Class EvoMark\LaravelIdObfuscator\Traits\EvoMark\LaravelIdObfuscator\Eloquent\Builder|static(App\Models\Example)
was not found while trying to analyse it - discovering symbols is probably not configured properly.
```

## Solution

Adding the missing preceding backslash to the classname `EvoMark\LaravelIdObfuscator\Eloquent\Builder` in the PHPDoc fixed the issue.

---

## Issue 2

```
Internal error: Class EvoMark\LaravelIdObfuscator\Eloquent\Builder|static(App\Models\Example) was not found while trying to analyse it - discovering symbols is probably not configured properly.
```

Same error message as before, but at least the pathname to the `Builder` class looks to be right now

## Solution

Removing the `static` return type from the PHPDoc got Larastan back up and running. What was the intention with including `static` in the PHPDoc? I'm likely missing something! 🤦 

Thank you again for this excellent project 😊 