### PR TITLE
Change encapsulation of obfuscatedId() attribute method

### DIFF
--- a/src/Traits/Obfuscatable.php
+++ b/src/Traits/Obfuscatable.php
@@ -9,7 +9,10 @@ use EvoMark\LaravelIdObfuscator\Facades\Obfuscate;
 
 trait Obfuscatable
 {
-    public function obfuscatedId(): Attribute
+    /**
+     * @return \Illuminate\Database\Eloquent\Casts\Attribute<string, never>
+     */
+    protected function obfuscatedId(): Attribute
     {
         return Attribute::make(
             get: fn() => Obfuscate::encode($this->{$this->getKeyName()})


### PR DESCRIPTION
Whilst performing static analysis of a Laravel 11 project, I run into the following error:

```
Access to an undefined property App\Models\Example::$obfuscatedId.
```

When investigating, I came across [this GitHub issue](https://github.com/larastan/larastan/issues/1739) which outlines the same problem. 

The outcome was that for Laravel Attributes to be recognised by static analysis, they should be `protected` methods as intended in [the Laravel docs](https://laravel.com/docs/11.x/eloquent-mutators#defining-an-accessor).

As per the [Larastan Docs](https://github.com/nunomaduro/larastan/blob/master/docs/features.md#laravel-9-attributes), the PHPDoc needs to also contain the return types of the getter and setter: In this case a `string` for the getter, and there is no setter, so a `never` for that.

Thanks for your patience with these PRs over the last 2 days. As far as I can tell, this will be my last.
Really appreciate your taking the time to look over them! 😊 